### PR TITLE
Fix too strict Action Taken filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .Rproj.user
+.Rhistory

--- a/R/server.R
+++ b/R/server.R
@@ -3199,9 +3199,9 @@ output$sel_aeacnn <- shiny::renderUI({
 
     is.convertible.to.flag <- function(x) as.character(x) %in% c("Y","y","Yes","yes","YES","1","0","N","n","No","NO","",".")
 
-    choices <- sort(c(names(which(apply(apply(adae,2,function(x){is.convertible.to.flag(x)}),2,all)))))
+    choices <- sort(c(names(adae)))
     if(!is.null(adsl)) {
-      choices2 <- names(which(apply(apply(adsl,2,function(x){is.convertible.to.flag(x)}),2,all)))
+      choices2 <- names(adsl)
       choices <- sort(c(choices, choices2))
     }
 

--- a/R/set_global_params.R
+++ b/R/set_global_params.R
@@ -28,7 +28,9 @@ set_global_params <- function(
   check_data(ae_data, patients)
 
   ## Local variables
-  Q <- initQ(ae_data)     # classification matrix of AEs (treatment-emergent, serious etc.)
+  Q <- initQ(ae_data %>% dplyr::select(      # classification matrix of AEs (treatment-emergent, serious etc.)
+    -c(replace_ae_start, replace_ae_end)     # remove variables that creat character(0) in drop down menu
+  ))
   AE_options <- 1:ncol(Q) # descriptions of AE classifications
   type_names <- data.frame(
     short = c(


### PR DESCRIPTION
AEACNN was assumed to be Yes/No-variable but can take value "DRUG WITHDRAWN". Thus, there oftentimes was no option to select the right variable. Additionally, fixed the two character(0) lines in the drop down menu.